### PR TITLE
Improve references

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,24 +204,6 @@ table.th90 th, table.th90 td {
           wgPublicList: "public-socialweb",
           wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/72531/status",
           localBiblio:  {
-            "Webmention": {
-              title:    "Webmention",
-              href:     "http://www.w3.org/TR/webmention",
-              authors:  [
-                "Aaron Parecki"
-              ],
-              status:   "REC",
-              publisher:  "W3C"
-            },
-            "ActivityStreams2": {
-              title: "ActivityStreams 2.0",
-              href: "http://www.w3.org/TR/activitystreams",
-              authors: [
-                "James Snell", "Evan Prodromou"
-              ],
-              status: "CR",
-              publisher: "W3C"
-            },
             "AS1": {
               title: "JSON Activity Streams 1.0.",
               href: "http://activitystrea.ms/specs/json/1.0/",
@@ -243,47 +225,12 @@ table.th90 th, table.th90 td {
               status: "Living specification",
               publisher: "IndieWebCamp"
             },
-            "AnnotationProtocol": {
-              title: "Web Annotation Protocol",
-              href: "https://www.w3.org/TR/annotation-protocol/",
-              authors: ["Rob Sanderson"],
-              status: "PR",
-              publisher: "W3C"
-            },
-            "AnnotationVocab": {
-              title: "Web Annotation Vocabulary",
-              href: "https://www.w3.org/TR/annotation-vocab/",
-              authors: ["Robert Sanderson", "Paolo Ciccarese", "Benjamin Young"],
-              status: "PR",
-              publisher: "W3C"
-            },
-            "LDN": {
-              title: "Linked Data Notifications",
-              href: "https://www.w3.org/tr/ldn/",
-              authors: ["Sarven Capadisli", "Amy Guy"],
-              status: "PR",
-              publisher: "W3C"
-            },
             "Accept-Post": {
               title: "The Accept-Post HTTP Header.",
               href: "http://tools.ietf.org/html/draft-wilde-accept-post",
               authors: ["J. Arwe", "S. Speicher", "E. Wilde"],
               status: "Internet Draft",
               publisher: "IETF"
-            },
-            "WebSub": {
-              title: "WebSub",
-              href: "https://www.w3.org/TR/websub",
-              authors: ["Julien Genestoux"],
-              status: "ED",
-              publisher: "W3C"
-            },
-            "mf2parsing": {
-              title: "Microformats2 Parsing Algorithm",
-              href: "http://microformats.org/wiki/microformats2-parsing",
-              authors: ["Tantek Çelik"],
-              status: "Living specification",
-              publisher: "microformats.org"
             }
           }
       };
@@ -380,7 +327,7 @@ table.th90 th, table.th90 td {
       <dl>
 
         <dt>ActivityStreams 1.0 [<a href="http://activitystrea.ms/specs/json/1.0/">External</a>]</dt>
-        <dd>The predecessor to [[ActivityStreams2]].</dd>
+        <dd>The predecessor to [[activitystreams-core]] and [[activitystreams-vocabulary]].</dd>
 
         <dt>Annotation Protocol [<a href="https://www.w3.org/TR/annotation-protocol/">WAWG CR</a>]</dt>
         <dd>Transport mechanisms for creating and managing annotations on the Web.</dd>
@@ -541,7 +488,7 @@ table.th90 th, table.th90 td {
     <section id="content-representation">
       <h3>Content representation</h3>
 
-      <p><strong>[[ActivityStreams2]]</strong> is the recommended syntax and vocabulary for social data. ActivityStreams 2.0 represents content and interactions as <em>Objects</em> and <em>Activities</em>. The ActivityStreams vocabulary defines a finite set of common Object and Activity types and properties, as well as an extension mechanism for applications which want to expand on or specialise these.</p>
+      <p><strong>[[activitystreams-core]]</strong> and <strong>[[activitystreams-vocabulary]]</strong> are the recommended syntax and vocabulary for social data, respectively. ActivityStreams 2.0 represents content and interactions as <em>Objects</em> and <em>Activities</em>. The ActivityStreams vocabulary defines a finite set of common Object and Activity types and properties, as well as an extension mechanism for applications which want to expand on or specialise these.</p>
 
       <p>ActivityStreams 2.0 content MUST be served with the Content-Type <code>application/activity+json</code> or for JSON-LD extended implementations, <code>application/ld+json; profile="https://www.w3.org/ns/activitystreams"</code>. Consumers should recognise both of these Content-Types as ActivityStreams 2.0.</p>
 
@@ -588,16 +535,16 @@ table.th90 th, table.th90 td {
         <p><strong>[[Activitypub]]</strong> specifies two streams that MUST be accessible from a profile via the following properties:</p>
 
         <ul>
-          <li><code>inbox</code>: A reference to an [[ActivityStreams2]] collection comprising all the objects received by the actor.</li>
-          <li><code>outbox</code>: An [[ActivityStreams2]] collection comprising all the objects produced by the actor.</li>
+          <li><code>inbox</code>: A reference to an [[activitystreams-core]] collection comprising all the objects received by the actor.</li>
+          <li><code>outbox</code>: An [[activitystreams-core]] collection comprising all the objects produced by the actor.</li>
         </ul>
 
         <p>[[Activitypub]] also specifies four further properties for accessing additional streams, which SHOULD or MAY be included in a profile:</p>
 
         <ul>
-          <li><code>following</code>: An [[ActivityStreams2]] collection of the actors that this actor is following.</li>
-          <li><code>followers</code>: An [[ActivityStreams2]] collection of the actors that follow this actor
-          <li><code>likes</code>: An [[ActivityStreams2]] collection of every <code>object</code> from all of the actor's <code>Like</code> activities (generated automatically by the server).</li>
+          <li><code>following</code>: An [[activitystreams-core]] collection of the actors that this actor is following.</li>
+          <li><code>followers</code>: An [[activitystreams-core]] collection of the actors that follow this actor
+          <li><code>likes</code>: An [[activitystreams-core]] collection of every <code>object</code> from all of the actor's <code>Like</code> activities (generated automatically by the server).</li>
           <li><code>streams</code>: A list of supplementary Collections which may be of interest. </li>
         </ul>
       
@@ -608,7 +555,7 @@ table.th90 th, table.th90 td {
         <h4>Inboxes</h4>
         <p>An Inbox is a collection or stream of objects to which new objects may be <a href="#delivery">delivered</a>. The contents of this collection may also be read. While ActivityPub and LDN align for <em>writing</em> to an Inbox, due to irritating but ultimately unavoidable compatibility requirements with AS2 and LDP respectively, they use different vocabularies when Inbox contents are returned for <em>reading</em>. Fortunately for consuming clients to check for both vocabularies or for publishers to publish using both is not a huge implementation hurdle, so bridging is fairly trivial.</p>
         <ul>
-          <li>ActivityPub Inboxes are an [[ActivityStreams2]] <code>OrderedCollection</code>, and link to their contents with the <code>items</code> property.</li>
+          <li>ActivityPub Inboxes are an [[activitystreams-core]] <code>OrderedCollection</code>, and link to their contents with the <code>items</code> property.</li>
           <li>LDN Inboxes are an [[LDP]] <code>Container</code>, and link to their contents with the <code>contains</code> property.</li>
         </ul>
 
@@ -663,11 +610,11 @@ table.th90 th, table.th90 td {
     <section id="creating">
       <h3>Creating</h3>
 
-      <p>The publishing endpoint of <strong>[[Activitypub]]</strong> is the <code>outbox</code>. Clients are assumed to have the URL of a (ideally authenticated) user profile as a starting point, and discover the value of the <code>https://www.w3.org/ns/activitystreams#outbox</code> property found at the profile URL (which should be available as JSON). The client then makes an HTTP <code>POST</code> request with an [[ActivityStreams2]] activity or object as a JSON payload with a content type of <code>application/ld+json; profile="https://www.w3.org/ns/activitystreams"</code>. The URL of the created resource is generated at the discretion of the server, and returned in the <code>Location</code> HTTP header. This is an appropriate protocol to use when:</p>
+      <p>The publishing endpoint of <strong>[[Activitypub]]</strong> is the <code>outbox</code>. Clients are assumed to have the URL of a (ideally authenticated) user profile as a starting point, and discover the value of the <code>https://www.w3.org/ns/activitystreams#outbox</code> property found at the profile URL (which should be available as JSON). The client then makes an HTTP <code>POST</code> request with an [[activitystreams-core]] activity or object as a JSON payload with a content type of <code>application/ld+json; profile="https://www.w3.org/ns/activitystreams"</code>. The URL of the created resource is generated at the discretion of the server, and returned in the <code>Location</code> HTTP header. This is an appropriate protocol to use when:</p>
 
       <ul>
         <li>You want to send/receive a JSON or JSON-LD payload.</li>
-        <li>Your data is described with [[ActivityStreams2]] (optionally extensible via JSON-LD).</li>
+        <li>Your data is described with [[activitystreams-core]] and [[activitystreams-vocabulary]] (optionally extensible via JSON-LD).</li>
         <li>You want serves to carry out a known set of actions upon content creation.</li>
       </ul>
 
@@ -690,7 +637,7 @@ table.th90 th, table.th90 td {
       
       <p>Content is updated when a client sends changes to attributes (additions, removals, replacements) to an existing object. If a server has implemented a <a href="#delivery">delivery</a> or <a href="#subscribing">subscription</a> mechanism, when an object is updated, the update MUST be propagated to the original recipients using the same mechanism.</p>
 
-      <p><strong>[[Activitypub]]</strong> clients send an HTTP <code>POST</code> request to the <code>outbox</code> containing an [[ActivityStreams2]] <code>Update</code> activity. The <code>object</code> of the activity is an existing object, and the fields to update should be nested. If a partial representation of an object is sent, omitted fields are <em>not</em> deleted by the server. In order to delete specific fields, the client can assign them a <code>null</code> value. However, when a federated server passes an <code>Update</code> activity to another server's <em><code>inbox</code></em>, the recipient must assume this is the <em>complete</em> object to be replaced; partial updates are not performed server-to-server.</p>
+      <p><strong>[[Activitypub]]</strong> clients send an HTTP <code>POST</code> request to the <code>outbox</code> containing an [[activitystreams-vocabulary]] <code>Update</code> activity. The <code>object</code> of the activity is an existing object, and the fields to update should be nested. If a partial representation of an object is sent, omitted fields are <em>not</em> deleted by the server. In order to delete specific fields, the client can assign them a <code>null</code> value. However, when a federated server passes an <code>Update</code> activity to another server's <em><code>inbox</code></em>, the recipient must assume this is the <em>complete</em> object to be replaced; partial updates are not performed server-to-server.</p>
 
       <p><strong>[[Micropub]]</strong> clients perform updates, as either form-encoded or JSON POST requests, using the <code>mp-action=update</code> parameter, as well as a <code>replace</code>, <code>add</code> or <code>delete</code> property containing the updates to make, to the Micropub endpoint. <code>replace</code> replaces all values of the specified property; if the property does not exist already, it is created. <code>add</code> adds new values to the specified property without changing the existing ones; if the property does not exist already, it is created. <code>delete</code> removes the specified property; you can also remove properties by value by specifying the value.</p>
       
@@ -701,7 +648,7 @@ table.th90 th, table.th90 td {
       
       <p>Content is deleted when a client sends a request to delete an existing object. If a server has implemented a <a href="#delivery">delivery</a> or <a href="#subscribing">subscription</a> mechanism, when an object is deleted, the deletion MUST be propagated to the original recipients using the same mechanism.</p>
 
-      <p><strong>[[Activitypub]]</strong> clients delete an object by sending an HTTP POST request containing an [[ActivityStreams2]] <code>Delete</code> activity to the <code>outbox</code> of the authenticated user. Servers MUST either <em>replace</em> the <code>object</code> of this activity with a tombstone and return a <code>410 Gone</code> status code, or return a <code>404 Not Found</code>, from its URL.</p>
+      <p><strong>[[Activitypub]]</strong> clients delete an object by sending an HTTP POST request containing an [[activitystreams-vocabulary]] <code>Delete</code> activity to the <code>outbox</code> of the authenticated user. Servers MUST either <em>replace</em> the <code>object</code> of this activity with a tombstone and return a <code>410 Gone</code> status code, or return a <code>404 Not Found</code>, from its URL.</p>
 
       <p><strong>[[Micropub]]</strong> delete requests are two key-value pairs, in form-encoded or JSON: <code>mp-action</code>: <code>delete</code> and <code>url</code>: <code>url-to-be-deleted</code>, sent to the Micropub endpoint .</p>
       
@@ -797,13 +744,13 @@ table.th90 th, table.th90 td {
       <p><strong>[[Activitypub]]</strong> uses [[LDN]] to send notifications with some specific constraints. These are:</p>
 
       <ul>
-        <li>The notification payload MUST be a single [[ActivityStreams2]] Activity.</li>
+        <li>The notification payload MUST be a single [[activitystreams-core]] Activity.</li>
         <li>The notification payload MUST be compact JSON-LD.</li>
         <li>The receiver MUST verify the notification by fetching its source from the origin server.</li>
         <li>All notification <code>POST</code> requests are authenticated.</li>
       </ul>
 
-      <p>[[Activitypub]] specifies how to define the <em>target(s)</em> to which a notification is to be sent (a pre-requisite to [[LDN]] sending), via the [[ActivityStreams2]] audience targeting and object linking properties.</p>
+      <p>[[Activitypub]] specifies how to define the <em>target(s)</em> to which a notification is to be sent (a pre-requisite to [[LDN]] sending), via the [[activitystreams-vocabulary]] audience targeting and object linking properties.</p>
 
       <p>[[Activitypub]] also defines side-effects that must be carried out by the server as a result of notification receipt. These include:</p>
 
@@ -896,7 +843,7 @@ table.th90 th, table.th90 td {
       <section id="wm-as-as">
         <h4>Webmention as AS2</h4>
 
-        <p>A webmention may be represented as a persistent resource with [[ActivityStreams2]]. This could come in handy if a Webmention sender <em>mentions</em> a user known to be running an [[Activitypub]] federated server. In this case, the sender can use an AS2 payload and carry out <a href="#delivery">delivery</a> of the notification per ActivityPub/LDN.</p>
+        <p>A webmention may be represented as a persistent resource with [[activitystreams-core]] and [[activitystreams-vocabulary]]. This could come in handy if a Webmention sender <em>mentions</em> a user known to be running an [[Activitypub]] federated server. In this case, the sender can use an AS2 payload and carry out <a href="#delivery">delivery</a> of the notification per ActivityPub/LDN.</p>
 
         <pre class="example">
   {

--- a/index.html
+++ b/index.html
@@ -236,19 +236,10 @@ table.th90 th, table.th90 td {
               status: "ED",
               publisher: "http://solid.mit.edu"
             },
-            "h-entry": {
-              title: "h-entry",
-              href: "http://microformats.org/wiki/h-entry",
-              authors: [
-                "Tantek Çelik"
-              ],
-              status:   "Living Specification",
-              publisher:  "microformats.org"
-            },
             "Salmentions": {
               title: "Salmentions",
               href: "http://indiewebcamp.com/Salmention",
-              authors: ["Ben Roberts, Tantek Çelik"],
+              authors: ["Ben Roberts", "Tantek Çelik"],
               status: "Living specification",
               publisher: "IndieWebCamp"
             },


### PR DESCRIPTION
I landed mf2 specs in SpecRef earlier today, and I got rid of the ones auto imported from W3C while I was at it.